### PR TITLE
Fix import loading indicator not resolving after OPML import

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -663,9 +663,9 @@
           failedUrls.push(f.title || f.url);
         }
       }
-      if (added > 0) statusEl.textContent = `Imported ${added} feed${added !== 1 ? 's' : ''}.`;
+      statusEl.textContent = added > 0 ? `Imported ${added} feed${added !== 1 ? 's' : ''}.` : '';
       if (failedUrls.length > 0) {
-        statusEl.textContent += ` ${failedUrls.length} failed. Try another CORS proxy in Settings or retry on Wi‑Fi.`;
+        statusEl.textContent += `${statusEl.textContent ? ' ' : ''}${failedUrls.length} failed. Try another CORS proxy in Settings or retry on Wi‑Fi.`;
       }
       e.target.value = '';
       await renderAll();


### PR DESCRIPTION
The "Importing…" status text was never cleared when all feeds in an OPML import failed. Line 666 only set statusEl.textContent when added > 0, so when every feed errored the text stayed as "Importing…" and the failure count was appended to it ("Importing… 5 failed...").

Fix: always assign statusEl.textContent after the loop (empty string when added === 0) so the loading text is replaced in every code path. Also avoid a leading space in the failure-only message.

https://claude.ai/code/session_01N1tT5mCXPvVobCVMPrBXpC