### PR TITLE
Add feed sharing via URL with import flow and tests

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -377,10 +377,13 @@ body[data-nav-position="bottom"] .toast {
 
 .feeds-toolbar {
   padding: 8px var(--padding-mobile);
+  display: flex;
+  gap: 8px;
 }
 
-.feeds-toolbar .btn-primary {
-  width: 100%;
+.feeds-toolbar .btn-primary,
+.feeds-toolbar .btn-secondary {
+  flex: 1;
 }
 
 /* Feed list */
@@ -1157,5 +1160,197 @@ body[data-nav-position="bottom"] .toast {
     padding-bottom: 32px;
   }
 
+}
+
+/* Share feeds dialog */
+.share-feeds-dialog {
+  position: fixed;
+  inset: 0;
+  z-index: 110;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: env(safe-area-inset-top, 0) 0 0 0;
+}
+
+.share-feeds-dialog[hidden] {
+  display: none;
+}
+
+.share-feeds-dialog-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.share-feeds-dialog-content {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+  max-height: 85vh;
+  overflow-y: auto;
+  background: var(--bg-elevated);
+  border-bottom-left-radius: 12px;
+  border-bottom-right-radius: 12px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.share-feeds-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: bold;
+  color: var(--text);
+}
+
+.share-feeds-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.share-feeds-controls .btn-secondary {
+  flex-shrink: 0;
+}
+
+.share-feeds-count {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.share-feeds-list {
+  border: 1px solid var(--border);
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.share-feeds-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px var(--padding-mobile);
+  border-bottom: 1px solid var(--border);
+  min-height: var(--touch-min);
+  cursor: pointer;
+}
+
+.share-feeds-item:last-child {
+  border-bottom: none;
+}
+
+.share-feeds-item input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.share-feeds-item input[type="checkbox"]:disabled {
+  cursor: not-allowed;
+}
+
+.share-feeds-item-label {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.9rem;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.share-feeds-item.disabled .share-feeds-item-label {
+  color: var(--text-muted);
+}
+
+.share-feeds-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.share-feeds-url-field {
+  width: 100%;
+  padding: 8px 10px;
+  font-size: 0.85rem;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+  font-family: inherit;
+  word-break: break-all;
+}
+
+/* Feed import dialog */
+.feed-import-dialog {
+  position: fixed;
+  inset: 0;
+  z-index: 110;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.feed-import-dialog[hidden] {
+  display: none;
+}
+
+.feed-import-dialog-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.feed-import-dialog-content {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+  max-height: 85vh;
+  overflow-y: auto;
+  background: var(--bg-elevated);
+  border-radius: 12px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.feed-import-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: bold;
+  color: var(--text);
+}
+
+.feed-import-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 240px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+}
+
+.feed-import-url {
+  padding: 8px var(--padding-mobile);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+  word-break: break-all;
+}
+
+.feed-import-url:last-child {
+  border-bottom: none;
+}
+
+.feed-import-status {
+  margin: 0;
+}
+
+.feed-import-actions {
+  display: flex;
+  gap: 8px;
 }
 

--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
         <div class="feeds-add-sticky">
           <div class="feeds-toolbar">
             <button type="button" id="btn-add-feed-top" class="btn-primary">+ Add feed</button>
+            <button type="button" id="btn-share-feeds" class="btn-secondary">Share feeds</button>
           </div>
         </div>
         <div id="feed-list" class="feed-list" role="list"></div>
@@ -287,11 +288,57 @@
     </div>
 
 
+    <!-- Share feeds dialog -->
+    <div id="share-feeds-dialog" class="share-feeds-dialog" hidden role="dialog" aria-modal="true" aria-label="Share feeds">
+      <div class="share-feeds-dialog-backdrop"></div>
+      <div class="share-feeds-dialog-content">
+        <div id="share-feeds-step-select">
+          <h2 class="share-feeds-title">Share feeds</h2>
+          <div class="share-feeds-controls">
+            <button type="button" id="share-feeds-select-all" class="btn-secondary">Select all</button>
+            <span id="share-feeds-count" class="share-feeds-count">0 of 15 feeds selected</span>
+          </div>
+          <p id="share-feeds-max-note" class="hint" hidden>Maximum 15 feeds per share link</p>
+          <div id="share-feeds-list" class="share-feeds-list"></div>
+          <div class="share-feeds-actions">
+            <button type="button" id="share-feeds-cancel" class="btn-secondary">Cancel</button>
+            <button type="button" id="share-feeds-generate" class="btn-primary" disabled>Generate link</button>
+          </div>
+        </div>
+        <div id="share-feeds-step-link" hidden>
+          <h2 class="share-feeds-title">Share link</h2>
+          <p class="hint">Anyone who opens this link will be prompted to import these feeds.</p>
+          <input type="text" id="share-feeds-url" class="share-feeds-url-field" readonly aria-label="Share link URL">
+          <div class="share-feeds-actions">
+            <button type="button" id="share-feeds-back" class="btn-secondary">Back</button>
+            <button type="button" id="share-feeds-copy" class="btn-secondary">Copy link</button>
+            <button type="button" id="share-feeds-share-btn" class="btn-primary">Share</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Feed import dialog (shown when ?import= param detected on load) -->
+    <div id="feed-import-dialog" class="feed-import-dialog" hidden role="dialog" aria-modal="true" aria-label="Import feeds from shared link">
+      <div class="feed-import-dialog-backdrop"></div>
+      <div class="feed-import-dialog-content">
+        <h2 class="feed-import-title">Import feeds from shared link?</h2>
+        <p id="feed-import-note" class="hint" hidden></p>
+        <ul id="feed-import-list" class="feed-import-list"></ul>
+        <p id="feed-import-status" class="feed-import-status hint" hidden aria-live="polite"></p>
+        <div class="feed-import-actions">
+          <button type="button" id="feed-import-cancel" class="btn-secondary">Cancel</button>
+          <button type="button" id="feed-import-btn" class="btn-primary">Import</button>
+        </div>
+      </div>
+    </div>
+
   <script src="js/config.js"></script>
   <script src="js/storage.js"></script>
   <script src="js/feed-parser.js"></script>
   <script src="js/ui.js"></script>
   <script src="js/updates.js"></script>
+  <script src="js/share.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1074,7 +1074,6 @@
       cancelBtn.disabled = false;
       cancelBtn.textContent = 'Cancel';
       dialog.hidden = false;
-      importBtn.focus();
 
       const close = () => { dialog.hidden = true; resolve(); };
       dialog.querySelector('.feed-import-dialog-backdrop').onclick = close;
@@ -1169,7 +1168,6 @@
       listEl.querySelectorAll('input[type="checkbox"]').forEach((cb) => cb.addEventListener('change', updateCount));
       updateCount();
       dialog.hidden = false;
-      (listEl.querySelector('input[type="checkbox"]:not(:disabled)') || selectAllBtn)?.focus();
     }
 
     document.getElementById('btn-share-feeds')?.addEventListener('click', showDialog);

--- a/js/app.js
+++ b/js/app.js
@@ -630,16 +630,18 @@
     }
   }
 
-  /** Add a feed when we already have the feed URL. Adds immediately, fetches in background. appleUrl = Apple Podcasts link (for podcasts from iTunes search). discoveryFallbackUrl = fallback URL to discover feed via HTML link scanning if feedUrl fails. */
-  async function addFeedByUrl(feedUrl, title, appleUrl = '', discoveryFallbackUrl = '') {
+  /** Add a feed when we already have the feed URL. Adds immediately, fetches in background. appleUrl = Apple Podcasts link (for podcasts from iTunes search). discoveryFallbackUrl = fallback URL to discover feed via HTML link scanning if feedUrl fails. Pass { quiet: true } to skip loadFeeds/renderAll (caller handles a single batch render). */
+  async function addFeedByUrl(feedUrl, title, appleUrl = '', discoveryFallbackUrl = '', { quiet = false } = {}) {
     const feed = { url: feedUrl, title: title || titleFromUrl(feedUrl) || 'Loading…', order: feeds.length, lastUpdate: Date.now() };
     if (appleUrl) {
       feed.appleUrl = appleUrl;
       feed.type = 'podcast';
     }
     const saved = await Storage.addFeed(feed);
-    await loadFeeds();
-    await renderAll();
+    if (!quiet) {
+      await loadFeeds();
+      await renderAll();
+    }
     fetchFeedInBackground(saved.id, feedUrl, appleUrl, discoveryFallbackUrl);
     return true;
   }
@@ -1072,6 +1074,7 @@
       cancelBtn.disabled = false;
       cancelBtn.textContent = 'Cancel';
       dialog.hidden = false;
+      importBtn.focus();
 
       const close = () => { dialog.hidden = true; resolve(); };
       dialog.querySelector('.feed-import-dialog-backdrop').onclick = close;
@@ -1089,11 +1092,16 @@
         let added = 0;
         for (const url of toAdd) {
           try {
-            await addFeedByUrl(url);
+            await addFeedByUrl(url, '', '', '', { quiet: true });
             added++;
           } catch {
             // silently skip invalid URLs
           }
+        }
+
+        if (added > 0) {
+          await loadFeeds();
+          await renderAll();
         }
 
         let msg;
@@ -1161,6 +1169,7 @@
       listEl.querySelectorAll('input[type="checkbox"]').forEach((cb) => cb.addEventListener('change', updateCount));
       updateCount();
       dialog.hidden = false;
+      (listEl.querySelector('input[type="checkbox"]:not(:disabled)') || selectAllBtn)?.focus();
     }
 
     document.getElementById('btn-share-feeds')?.addEventListener('click', showDialog);
@@ -1573,8 +1582,9 @@
 
   async function init() {
     // Strip ?import= param immediately so a page refresh never re-prompts.
-    const importParam = FeedShare?.getImportParam(window.location.search) || null;
-    if (importParam) FeedShare.stripImportParam();
+    // Use ?? null (not || null) so an empty ?import= value is still detected and stripped.
+    const importParam = FeedShare?.getImportParam(window.location.search) ?? null;
+    if (importParam !== null) FeedShare.stripImportParam();
 
     if ('serviceWorker' in navigator) {
       try {
@@ -1605,7 +1615,7 @@
     wireShareAndInstall();
     wirePullToRefresh();
 
-    if (importParam) await handleFeedShareImport(importParam);
+    if (importParam !== null) await handleFeedShareImport(importParam);
 
     if (feeds.length > 0) await refreshAllFeeds();
     scheduleRefresh();

--- a/js/app.js
+++ b/js/app.js
@@ -18,6 +18,7 @@
   const Storage = window.Storage;
   const FeedParser = window.FeedParser;
   const UI = window.UI;
+  const FeedShare = window.FeedShare;
 
   let feeds = [];
   let feedMap = {};
@@ -1036,6 +1037,198 @@
     document.getElementById('add-feed-resolve-yt')?.addEventListener('click', resolveYoutubeInput);
   }
 
+  /** Handle ?import= param on app load: decode, validate, show dialog. */
+  async function handleFeedShareImport(importParam) {
+    const result = FeedShare.decodeFeedUrls(importParam);
+    if (result.error === 'invalid_base64' || result.error === 'invalid_json' || result.error === 'not_array') {
+      showToast('This share link appears to be invalid or corrupted.', 5000);
+      return;
+    }
+    if (result.error === 'empty') {
+      showToast('This share link contains no feeds.', 5000);
+      return;
+    }
+    await showFeedImportDialog(result.urls, result.truncated);
+  }
+
+  /** Show the feed import modal and return a Promise that resolves when dismissed. */
+  function showFeedImportDialog(urls, truncated) {
+    return new Promise((resolve) => {
+      const dialog = document.getElementById('feed-import-dialog');
+      if (!dialog) { resolve(); return; }
+      const feedListEl = document.getElementById('feed-import-list');
+      const noteEl = document.getElementById('feed-import-note');
+      const statusEl = document.getElementById('feed-import-status');
+      const importBtn = document.getElementById('feed-import-btn');
+      const cancelBtn = document.getElementById('feed-import-cancel');
+
+      feedListEl.innerHTML = urls.map((url) => `<li class="feed-import-url">${UI.escapeHtml(url)}</li>`).join('');
+      noteEl.textContent = truncated ? 'This link contained more than 15 feeds. Only the first 15 are shown.' : '';
+      noteEl.hidden = !truncated;
+      statusEl.textContent = '';
+      statusEl.hidden = true;
+      importBtn.hidden = false;
+      importBtn.disabled = false;
+      cancelBtn.disabled = false;
+      cancelBtn.textContent = 'Cancel';
+      dialog.hidden = false;
+
+      const close = () => { dialog.hidden = true; resolve(); };
+      dialog.querySelector('.feed-import-dialog-backdrop').onclick = close;
+      cancelBtn.onclick = close;
+
+      importBtn.onclick = async () => {
+        importBtn.disabled = true;
+        cancelBtn.disabled = true;
+        statusEl.textContent = 'Importing…';
+        statusEl.hidden = false;
+
+        const existingFeeds = await Storage.getFeeds();
+        const { toAdd, skipped } = FeedShare.planImport(urls, existingFeeds.map((f) => f.url));
+
+        let added = 0;
+        for (const url of toAdd) {
+          try {
+            await addFeedByUrl(url);
+            added++;
+          } catch {
+            // silently skip invalid URLs
+          }
+        }
+
+        let msg;
+        if (added === 0 && skipped > 0) {
+          msg = 'All feeds already in your list';
+        } else if (added > 0 && skipped > 0) {
+          msg = `${added} feed${added !== 1 ? 's' : ''} added, ${skipped} already in your list`;
+        } else {
+          msg = `${added} feed${added !== 1 ? 's' : ''} added`;
+        }
+        statusEl.textContent = msg;
+        importBtn.hidden = true;
+        cancelBtn.disabled = false;
+        cancelBtn.textContent = 'Done';
+      };
+    });
+  }
+
+  /** Wire the "Share feeds" button and dialog (feed selection → link display). */
+  function wireShareFeeds() {
+    const dialog = document.getElementById('share-feeds-dialog');
+    if (!dialog) return;
+    const backdrop = dialog.querySelector('.share-feeds-dialog-backdrop');
+    const stepSelect = document.getElementById('share-feeds-step-select');
+    const stepLink = document.getElementById('share-feeds-step-link');
+    const selectAllBtn = document.getElementById('share-feeds-select-all');
+    const countEl = document.getElementById('share-feeds-count');
+    const maxNoteEl = document.getElementById('share-feeds-max-note');
+    const listEl = document.getElementById('share-feeds-list');
+    const cancelBtn = document.getElementById('share-feeds-cancel');
+    const generateBtn = document.getElementById('share-feeds-generate');
+    const urlField = document.getElementById('share-feeds-url');
+    const backBtn = document.getElementById('share-feeds-back');
+    const copyBtn = document.getElementById('share-feeds-copy');
+    const shareBtn = document.getElementById('share-feeds-share-btn');
+    const max = FeedShare.MAX_FEEDS;
+
+    function close() { dialog.hidden = true; }
+
+    function updateCount() {
+      const checkboxes = listEl.querySelectorAll('input[type="checkbox"]');
+      const checked = listEl.querySelectorAll('input[type="checkbox"]:checked');
+      const count = checked.length;
+      countEl.textContent = `${count} of ${max} feeds selected`;
+      selectAllBtn.textContent = checkboxes.length > 0 && count === checkboxes.length ? 'Deselect all' : 'Select all';
+      maxNoteEl.hidden = count < max;
+      generateBtn.disabled = count === 0;
+      checkboxes.forEach((cb) => {
+        const item = cb.closest('.share-feeds-item');
+        const atMax = !cb.checked && count >= max;
+        cb.disabled = atMax;
+        item?.classList.toggle('disabled', atMax);
+      });
+    }
+
+    function showDialog() {
+      stepSelect.hidden = false;
+      stepLink.hidden = true;
+      listEl.innerHTML = feeds.map((f) => `
+        <label class="share-feeds-item">
+          <input type="checkbox" value="${UI.escapeHtml(f.url)}">
+          <span class="share-feeds-item-label">${UI.escapeHtml(f.title || f.url)}</span>
+        </label>
+      `).join('');
+      listEl.querySelectorAll('input[type="checkbox"]').forEach((cb) => cb.addEventListener('change', updateCount));
+      updateCount();
+      dialog.hidden = false;
+    }
+
+    document.getElementById('btn-share-feeds')?.addEventListener('click', showDialog);
+    backdrop?.addEventListener('click', close);
+    cancelBtn?.addEventListener('click', close);
+    dialog.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
+
+    selectAllBtn?.addEventListener('click', () => {
+      const checkboxes = listEl.querySelectorAll('input[type="checkbox"]');
+      const allChecked = Array.from(checkboxes).every((cb) => cb.checked);
+      if (allChecked) {
+        checkboxes.forEach((cb) => { cb.checked = false; cb.disabled = false; });
+      } else {
+        let count = 0;
+        checkboxes.forEach((cb) => {
+          if (count < max) { cb.checked = true; count++; }
+          else cb.checked = false;
+          cb.disabled = false;
+        });
+      }
+      updateCount();
+    });
+
+    generateBtn?.addEventListener('click', () => {
+      const urls = Array.from(listEl.querySelectorAll('input[type="checkbox"]:checked')).map((cb) => cb.value);
+      if (urls.length === 0) return;
+      try {
+        urlField.value = FeedShare.buildShareUrl(urls);
+        stepSelect.hidden = true;
+        stepLink.hidden = false;
+        urlField.select();
+      } catch {
+        showToast('Could not generate share link.');
+      }
+    });
+
+    backBtn?.addEventListener('click', () => { stepSelect.hidden = false; stepLink.hidden = true; });
+
+    copyBtn?.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(urlField.value);
+      } catch {
+        urlField.select();
+        document.execCommand('copy');
+      }
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => { copyBtn.textContent = 'Copy link'; }, 2000);
+    });
+
+    shareBtn?.addEventListener('click', async () => {
+      const url = urlField.value;
+      if (!url) return;
+      try {
+        if (navigator.share) {
+          await navigator.share({ title: 'My RSS feeds — JustRSS', url });
+        } else {
+          await navigator.clipboard.writeText(url);
+          showToast('Link copied');
+        }
+      } catch (e) {
+        if (e.name !== 'AbortError') {
+          try { await navigator.clipboard.writeText(url); } catch { /* ignore */ }
+          showToast('Link copied');
+        }
+      }
+    });
+  }
+
   function wireFeeds() {
   }
 
@@ -1379,6 +1572,10 @@
   }
 
   async function init() {
+    // Strip ?import= param immediately so a page refresh never re-prompts.
+    const importParam = FeedShare?.getImportParam(window.location.search) || null;
+    if (importParam) FeedShare.stripImportParam();
+
     if ('serviceWorker' in navigator) {
       try {
         await navigator.serviceWorker.register('service-worker.js');
@@ -1401,11 +1598,14 @@
     wireNavigation();
     wireAddFeedDialog();
     wireFeeds();
+    wireShareFeeds();
     wireLoadMore();
     wireArticleReader();
     wireSettings();
     wireShareAndInstall();
     wirePullToRefresh();
+
+    if (importParam) await handleFeedShareImport(importParam);
 
     if (feeds.length > 0) await refreshAllFeeds();
     scheduleRefresh();

--- a/js/share.js
+++ b/js/share.js
@@ -19,13 +19,32 @@
   const MAX_FEEDS = 15;
 
   /**
+   * UTF-8–safe base64 encode. Works for any valid URL string including IDNs.
+   * For ASCII-only content (all typical feed URLs) the output is identical
+   * to btoa(str), so existing encoded links remain valid.
+   * Uses the encodeURIComponent→unescape→btoa idiom (universally available).
+   */
+  function toBase64(str) {
+    // eslint-disable-next-line no-unescape-usage
+    return btoa(unescape(encodeURIComponent(str)));
+  }
+
+  /**
+   * UTF-8–safe base64 decode. Throws if input is not valid base64.
+   */
+  function fromBase64(b64) {
+    // eslint-disable-next-line no-unescape-usage
+    return decodeURIComponent(escape(atob(b64)));
+  }
+
+  /**
    * Encode an array of feed URLs as base64 JSON.
    * Throws if urls is not an array or exceeds MAX_FEEDS.
    */
   function encodeFeedUrls(urls) {
     if (!Array.isArray(urls)) throw new Error('Expected array of URLs');
     if (urls.length > MAX_FEEDS) throw new Error(`Maximum ${MAX_FEEDS} feeds per share link`);
-    return btoa(JSON.stringify(urls));
+    return toBase64(JSON.stringify(urls));
   }
 
   /**
@@ -37,7 +56,7 @@
   function decodeFeedUrls(encoded) {
     let decoded;
     try {
-      decoded = atob(encoded);
+      decoded = fromBase64(encoded);
     } catch {
       return { urls: null, error: 'invalid_base64', truncated: false };
     }
@@ -63,17 +82,19 @@
 
   /**
    * Build a share URL for the given feed URLs.
-   * Uses the current page's origin + pathname as the base.
+   * Uses URLSearchParams.set so the base64 payload (which may contain +, =, /)
+   * is percent-encoded and survives a query-string round-trip without corruption.
    */
   function buildShareUrl(urls) {
     const encoded = encodeFeedUrls(urls);
-    const base = window.location.origin + window.location.pathname;
-    return `${base}?import=${encoded}`;
+    const url = new URL(window.location.origin + window.location.pathname);
+    url.searchParams.set('import', encoded);
+    return url.toString();
   }
 
   /**
    * Extract the ?import= param from a URL search string.
-   * Returns null if not present.
+   * Returns null if not present, or the raw string value (possibly empty) if present.
    * Pure — does not touch window; pass window.location.search as argument.
    */
   function getImportParam(search) {
@@ -93,13 +114,22 @@
 
   /**
    * Given a list of URLs to import and a list of existing feed URLs,
-   * return { toAdd: string[], skipped: number } where toAdd are new URLs only.
+   * return { toAdd: string[], skipped: number } where toAdd contains each
+   * new, valid URL at most once (deduplicates within the import list too).
    * Pure — no side effects.
    */
   function planImport(urls, existingUrls) {
-    const existingSet = new Set(existingUrls);
-    const toAdd = urls.filter((url) => url && typeof url === 'string' && !existingSet.has(url));
-    const skipped = urls.length - toAdd.length;
+    const seen = new Set(existingUrls);
+    const toAdd = [];
+    let skipped = 0;
+    urls.forEach((url) => {
+      if (!url || typeof url !== 'string' || seen.has(url)) {
+        skipped++;
+        return;
+      }
+      seen.add(url);
+      toAdd.push(url);
+    });
     return { toAdd, skipped };
   }
 

--- a/js/share.js
+++ b/js/share.js
@@ -1,0 +1,115 @@
+/**
+ * JustRSS - A minimal, intentional RSS reader
+ * Copyright (C) 2025 rkbarney
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Source: https://github.com/rkbarney/justrss
+ */
+
+/**
+ * Feed sharing: encode/decode feed URLs for share links.
+ * Pure functions — no DOM dependency except buildShareUrl and stripImportParam.
+ */
+
+(function () {
+  const MAX_FEEDS = 15;
+
+  /**
+   * Encode an array of feed URLs as base64 JSON.
+   * Throws if urls is not an array or exceeds MAX_FEEDS.
+   */
+  function encodeFeedUrls(urls) {
+    if (!Array.isArray(urls)) throw new Error('Expected array of URLs');
+    if (urls.length > MAX_FEEDS) throw new Error(`Maximum ${MAX_FEEDS} feeds per share link`);
+    return btoa(JSON.stringify(urls));
+  }
+
+  /**
+   * Decode a base64 encoded feed URL list.
+   * Returns { urls: string[]|null, error: string|null, truncated: boolean }
+   * Possible error values: 'invalid_base64', 'invalid_json', 'not_array', 'empty'
+   * On success: error is null, urls is an array (possibly truncated to MAX_FEEDS).
+   */
+  function decodeFeedUrls(encoded) {
+    let decoded;
+    try {
+      decoded = atob(encoded);
+    } catch {
+      return { urls: null, error: 'invalid_base64', truncated: false };
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(decoded);
+    } catch {
+      return { urls: null, error: 'invalid_json', truncated: false };
+    }
+    if (!Array.isArray(parsed)) {
+      return { urls: null, error: 'not_array', truncated: false };
+    }
+    if (parsed.length === 0) {
+      return { urls: [], error: 'empty', truncated: false };
+    }
+    let truncated = false;
+    if (parsed.length > MAX_FEEDS) {
+      parsed = parsed.slice(0, MAX_FEEDS);
+      truncated = true;
+    }
+    return { urls: parsed, error: null, truncated };
+  }
+
+  /**
+   * Build a share URL for the given feed URLs.
+   * Uses the current page's origin + pathname as the base.
+   */
+  function buildShareUrl(urls) {
+    const encoded = encodeFeedUrls(urls);
+    const base = window.location.origin + window.location.pathname;
+    return `${base}?import=${encoded}`;
+  }
+
+  /**
+   * Extract the ?import= param from a URL search string.
+   * Returns null if not present.
+   * Pure — does not touch window; pass window.location.search as argument.
+   */
+  function getImportParam(search) {
+    const params = new URLSearchParams(search);
+    return params.get('import');
+  }
+
+  /**
+   * Strip the ?import= param from the current URL using history.replaceState.
+   * No-op if there is no import param.
+   */
+  function stripImportParam() {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('import');
+    history.replaceState(null, '', url.pathname + url.search + url.hash);
+  }
+
+  /**
+   * Given a list of URLs to import and a list of existing feed URLs,
+   * return { toAdd: string[], skipped: number } where toAdd are new URLs only.
+   * Pure — no side effects.
+   */
+  function planImport(urls, existingUrls) {
+    const existingSet = new Set(existingUrls);
+    const toAdd = urls.filter((url) => url && typeof url === 'string' && !existingSet.has(url));
+    const skipped = urls.length - toAdd.length;
+    return { toAdd, skipped };
+  }
+
+  window.FeedShare = {
+    MAX_FEEDS,
+    encodeFeedUrls,
+    decodeFeedUrls,
+    buildShareUrl,
+    getImportParam,
+    stripImportParam,
+    planImport,
+  };
+})();

--- a/tests/share.test.js
+++ b/tests/share.test.js
@@ -209,6 +209,15 @@ describe('planImport', () => {
     assert.deepEqual([...toAdd], ['https://valid.com/feed']);
     assert.strictEqual(skipped, 3);
   });
+
+  it('deduplicates URLs appearing more than once in the import list', () => {
+    const { toAdd, skipped } = FeedShare.planImport(
+      ['https://a.com/feed', 'https://b.com/rss', 'https://a.com/feed'],
+      [],
+    );
+    assert.deepEqual([...toAdd], ['https://a.com/feed', 'https://b.com/rss']);
+    assert.strictEqual(skipped, 1);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -237,6 +246,42 @@ describe('getImportParam', () => {
     const encoded = FeedShare.encodeFeedUrls(urls);
     const param = FeedShare.getImportParam(`?import=${encoded}`);
     assert.strictEqual(param, encoded);
+  });
+
+  it('preserves a payload containing + when round-tripped through a query string', () => {
+    // Standard Base64 uses +, /, and =. URLSearchParams treats bare + as space,
+    // so buildShareUrl must percent-encode the payload. This verifies getImportParam
+    // restores the original value (including +) after encoding via URLSearchParams.
+    const encoded = 'abc+def/ghi==';
+    const search = `?${new URLSearchParams({ import: encoded }).toString()}`;
+    const param = FeedShare.getImportParam(search);
+    assert.strictEqual(param, encoded);
+  });
+});
+
+describe('buildShareUrl', () => {
+  it('produces a URL whose ?import= value survives a full round-trip decode', () => {
+    const { FeedShare: fs } = loadFeedShareDom('http://localhost/');
+    const urls = ['https://example.com/feed', 'https://another.org/rss'];
+    const shareUrl = fs.buildShareUrl(urls);
+    const param = fs.getImportParam(new URL(shareUrl).search);
+    const result = fs.decodeFeedUrls(param);
+    assert.strictEqual(result.error, null);
+    assert.strictEqual(result.urls.length, 2);
+    assert.strictEqual(result.urls[0], urls[0]);
+    assert.strictEqual(result.urls[1], urls[1]);
+  });
+
+  it('percent-encodes + characters so they are not decoded as spaces', () => {
+    // A payload containing + (common in base64) must not be corrupted by query string parsing.
+    const { FeedShare: fs } = loadFeedShareDom('http://localhost/');
+    // Generate a URL list whose encoding is known to contain '+' in standard base64
+    // by testing that getImportParam(new URL(shareUrl).search) === the original encoded value.
+    const urls = ['https://example.com/feed'];
+    const encoded = fs.encodeFeedUrls(urls);
+    const shareUrl = fs.buildShareUrl(urls);
+    const recovered = fs.getImportParam(new URL(shareUrl).search);
+    assert.strictEqual(recovered, encoded);
   });
 });
 

--- a/tests/share.test.js
+++ b/tests/share.test.js
@@ -1,0 +1,306 @@
+/**
+ * Feed sharing tests: encode/decode/validate, deduplication, URL param handling.
+ * Run with: npm test
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Load FeedShare into a JSDOM environment at the given URL.
+ * Returns { FeedShare, dom } so callers can inspect window state.
+ */
+function loadFeedShareDom(url = 'http://localhost/') {
+  const code = readFileSync(join(__dirname, '../js/share.js'), 'utf8');
+  const html = `<!DOCTYPE html><html><body><script>${code}</script></body></html>`;
+  const dom = new JSDOM(html, { url, runScripts: 'dangerously' });
+  return { FeedShare: dom.window.FeedShare, dom };
+}
+
+// Module-level instance for pure-function tests (no window state needed).
+const { FeedShare } = loadFeedShareDom();
+
+// Helper: encode in the JSDOM context so atob/btoa are consistent.
+function b64encode(str) {
+  const { dom } = loadFeedShareDom();
+  return dom.window.btoa(str);
+}
+
+// ---------------------------------------------------------------------------
+// Encoding
+// ---------------------------------------------------------------------------
+
+describe('encodeFeedUrls', () => {
+  it('encodes a valid list of URLs to a non-empty base64 string', () => {
+    const encoded = FeedShare.encodeFeedUrls(['https://example.com/feed']);
+    assert.ok(typeof encoded === 'string' && encoded.length > 0);
+  });
+
+  it('round-trip: decoding returns the original URLs unchanged', () => {
+    const urls = ['https://a.com/feed', 'https://b.com/rss', 'https://c.org/atom.xml'];
+    const encoded = FeedShare.encodeFeedUrls(urls);
+    const result = FeedShare.decodeFeedUrls(encoded);
+    assert.strictEqual(result.error, null);
+    // deepEqual (not strict) handles cross-realm array comparison
+    assert.deepEqual([...result.urls], urls);
+  });
+
+  it('encodes 1 feed', () => {
+    const encoded = FeedShare.encodeFeedUrls(['https://single.com/feed']);
+    assert.ok(encoded.length > 0);
+  });
+
+  it('encodes 10 feeds', () => {
+    const urls = Array.from({ length: 10 }, (_, i) => `https://feed${i}.com/rss`);
+    const encoded = FeedShare.encodeFeedUrls(urls);
+    assert.ok(encoded.length > 0);
+  });
+
+  it('encodes 15 feeds (at cap)', () => {
+    const urls = Array.from({ length: 15 }, (_, i) => `https://feed${i}.com/rss`);
+    const encoded = FeedShare.encodeFeedUrls(urls);
+    assert.ok(encoded.length > 0);
+  });
+
+  it('throws when encoding 16+ feeds (cap enforced)', () => {
+    const urls = Array.from({ length: 16 }, (_, i) => `https://feed${i}.com/rss`);
+    assert.throws(() => FeedShare.encodeFeedUrls(urls), /Maximum 15/);
+  });
+
+  it('throws when encoding 20 feeds', () => {
+    const urls = Array.from({ length: 20 }, (_, i) => `https://feed${i}.com/rss`);
+    assert.throws(() => FeedShare.encodeFeedUrls(urls));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Decoding & validation
+// ---------------------------------------------------------------------------
+
+describe('decodeFeedUrls', () => {
+  it('handles malformed base64 without throwing (error: invalid_base64)', () => {
+    const result = FeedShare.decodeFeedUrls('!!!not-base64!!!');
+    assert.strictEqual(result.error, 'invalid_base64');
+    assert.strictEqual(result.urls, null);
+    assert.strictEqual(result.truncated, false);
+  });
+
+  it('handles valid base64 but non-JSON content (error: invalid_json)', () => {
+    const encoded = b64encode('not-json-at-all{{{{');
+    const result = FeedShare.decodeFeedUrls(encoded);
+    assert.strictEqual(result.error, 'invalid_json');
+    assert.strictEqual(result.urls, null);
+  });
+
+  it('handles valid base64 + valid JSON that is not an array — plain object (error: not_array)', () => {
+    const encoded = b64encode(JSON.stringify({ url: 'https://example.com/feed' }));
+    const result = FeedShare.decodeFeedUrls(encoded);
+    assert.strictEqual(result.error, 'not_array');
+    assert.strictEqual(result.urls, null);
+  });
+
+  it('handles valid base64 + valid JSON that is not an array — string (error: not_array)', () => {
+    const encoded = b64encode(JSON.stringify('https://example.com/feed'));
+    const result = FeedShare.decodeFeedUrls(encoded);
+    assert.strictEqual(result.error, 'not_array');
+    assert.strictEqual(result.urls, null);
+  });
+
+  it('handles valid base64 + valid JSON that is not an array — number (error: not_array)', () => {
+    const encoded = b64encode(JSON.stringify(42));
+    const result = FeedShare.decodeFeedUrls(encoded);
+    assert.strictEqual(result.error, 'not_array');
+    assert.strictEqual(result.urls, null);
+  });
+
+  it('handles an empty array (error: empty, urls: [])', () => {
+    const encoded = b64encode(JSON.stringify([]));
+    const result = FeedShare.decodeFeedUrls(encoded);
+    assert.strictEqual(result.error, 'empty');
+    assert.ok(result.urls !== null);
+    assert.strictEqual(result.urls.length, 0);
+    assert.strictEqual(result.truncated, false);
+  });
+
+  it('truncates arrays exceeding 15 items and sets truncated=true', () => {
+    const urls = Array.from({ length: 20 }, (_, i) => `https://feed${i}.com/rss`);
+    const encoded = b64encode(JSON.stringify(urls));
+    const result = FeedShare.decodeFeedUrls(encoded);
+    assert.strictEqual(result.error, null);
+    assert.strictEqual(result.truncated, true);
+    assert.strictEqual(result.urls.length, 15);
+    // Compare individual strings (cross-realm safe)
+    for (let i = 0; i < 15; i++) {
+      assert.strictEqual(result.urls[i], urls[i]);
+    }
+  });
+
+  it('does not truncate arrays of exactly 15 items', () => {
+    const urls = Array.from({ length: 15 }, (_, i) => `https://feed${i}.com/rss`);
+    const encoded = FeedShare.encodeFeedUrls(urls);
+    const result = FeedShare.decodeFeedUrls(encoded);
+    assert.strictEqual(result.error, null);
+    assert.strictEqual(result.truncated, false);
+    assert.strictEqual(result.urls.length, 15);
+  });
+
+  it('succeeds for a valid single-item array (no error)', () => {
+    const encoded = FeedShare.encodeFeedUrls(['https://waitbutwhy.com/feed']);
+    const result = FeedShare.decodeFeedUrls(encoded);
+    assert.strictEqual(result.error, null);
+    assert.strictEqual(result.urls.length, 1);
+    assert.strictEqual(result.urls[0], 'https://waitbutwhy.com/feed');
+    assert.strictEqual(result.truncated, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Import deduplication (planImport is pure)
+// ---------------------------------------------------------------------------
+
+describe('planImport', () => {
+  it('skips a URL already in the existing feed list', () => {
+    const existing = ['https://existing.com/feed', 'https://other.com/rss'];
+    const { toAdd, skipped } = FeedShare.planImport(['https://existing.com/feed'], existing);
+    assert.deepEqual([...toAdd], []);
+    assert.strictEqual(skipped, 1);
+  });
+
+  it('adds URLs not in the existing list', () => {
+    const existing = ['https://existing.com/feed'];
+    const { toAdd, skipped } = FeedShare.planImport(
+      ['https://existing.com/feed', 'https://new.com/rss', 'https://another.com/atom'],
+      existing,
+    );
+    assert.deepEqual([...toAdd], ['https://new.com/rss', 'https://another.com/atom']);
+    assert.strictEqual(skipped, 1);
+  });
+
+  it('returns 0 feeds to add when all are duplicates', () => {
+    const existing = ['https://a.com/feed', 'https://b.com/rss'];
+    const { toAdd, skipped } = FeedShare.planImport(
+      ['https://a.com/feed', 'https://b.com/rss'],
+      existing,
+    );
+    assert.strictEqual(toAdd.length, 0);
+    assert.strictEqual(skipped, 2);
+  });
+
+  it('adds all URLs when none are duplicates', () => {
+    const { toAdd, skipped } = FeedShare.planImport(
+      ['https://new1.com/feed', 'https://new2.com/rss'],
+      [],
+    );
+    assert.deepEqual([...toAdd], ['https://new1.com/feed', 'https://new2.com/rss']);
+    assert.strictEqual(skipped, 0);
+  });
+
+  it('filters out falsy entries silently', () => {
+    const { toAdd, skipped } = FeedShare.planImport(
+      ['https://valid.com/feed', '', null, undefined],
+      [],
+    );
+    assert.deepEqual([...toAdd], ['https://valid.com/feed']);
+    assert.strictEqual(skipped, 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// URL param handling
+// ---------------------------------------------------------------------------
+
+describe('getImportParam', () => {
+  it('detects the ?import= param in a search string', () => {
+    const param = FeedShare.getImportParam('?import=abc123');
+    assert.strictEqual(param, 'abc123');
+  });
+
+  it('returns null when ?import= param is absent', () => {
+    assert.strictEqual(FeedShare.getImportParam('?foo=bar'), null);
+    assert.strictEqual(FeedShare.getImportParam(''), null);
+    assert.strictEqual(FeedShare.getImportParam('?'), null);
+  });
+
+  it('returns the correct value when other params are also present', () => {
+    const param = FeedShare.getImportParam('?foo=bar&import=xyz&baz=1');
+    assert.strictEqual(param, 'xyz');
+  });
+
+  it('works with a real encoded share link', () => {
+    const urls = ['https://example.com/feed'];
+    const encoded = FeedShare.encodeFeedUrls(urls);
+    const param = FeedShare.getImportParam(`?import=${encoded}`);
+    assert.strictEqual(param, encoded);
+  });
+});
+
+describe('stripImportParam', () => {
+  it('removes ?import= from the URL via history.replaceState', () => {
+    const { FeedShare: fs, dom } = loadFeedShareDom('http://localhost/?import=abc123');
+    assert.ok(dom.window.location.search.includes('import'));
+    fs.stripImportParam();
+    assert.ok(!dom.window.location.search.includes('import'));
+    assert.ok(!dom.window.location.href.includes('import'));
+  });
+
+  it('preserves other query params when stripping', () => {
+    const { FeedShare: fs, dom } = loadFeedShareDom('http://localhost/?foo=bar&import=abc&baz=1');
+    fs.stripImportParam();
+    assert.ok(!dom.window.location.search.includes('import'));
+    assert.ok(dom.window.location.search.includes('foo=bar'));
+    assert.ok(dom.window.location.search.includes('baz=1'));
+  });
+
+  it('preserves the URL hash when stripping', () => {
+    const { FeedShare: fs, dom } = loadFeedShareDom('http://localhost/?import=abc#feeds');
+    fs.stripImportParam();
+    assert.ok(!dom.window.location.href.includes('import'));
+    assert.ok(dom.window.location.hash === '#feeds');
+  });
+
+  it('is a no-op when ?import= is not present', () => {
+    const { FeedShare: fs, dom } = loadFeedShareDom('http://localhost/?foo=bar');
+    fs.stripImportParam();
+    assert.ok(!dom.window.location.href.includes('import'));
+    assert.ok(dom.window.location.href.includes('foo=bar'));
+  });
+
+  it('param is stripped on error path (invalid param stripped at init)', () => {
+    // Simulate: param detected → stripped immediately → then validation fails
+    const { FeedShare: fs, dom } = loadFeedShareDom('http://localhost/?import=!!!bad!!!');
+    const param = fs.getImportParam(dom.window.location.search);
+    assert.ok(param !== null);
+    fs.stripImportParam();
+    assert.ok(!dom.window.location.href.includes('import'));
+    // Now validate — this would show the error toast in app context
+    const result = fs.decodeFeedUrls(param);
+    assert.strictEqual(result.error, 'invalid_base64');
+  });
+
+  it('param is stripped on cancel path (stripped at init before dialog shown)', () => {
+    // The app strips the param at the very start of init(), before the dialog appears.
+    // This test verifies stripping works regardless of user action.
+    const { FeedShare: fs, dom } = loadFeedShareDom('http://localhost/?import=abc123#all');
+    fs.stripImportParam();
+    assert.ok(!dom.window.location.href.includes('import'));
+    assert.ok(dom.window.location.hash === '#all');
+  });
+
+  it('param is stripped on successful import path', () => {
+    const urls = ['https://example.com/feed', 'https://another.com/rss'];
+    const encoded = FeedShare.encodeFeedUrls(urls); // compute before destructuring
+    const { FeedShare: fs, dom } = loadFeedShareDom(`http://localhost/?import=${encoded}`);
+    fs.stripImportParam();
+    assert.ok(!dom.window.location.href.includes('import'));
+    // Decoding still works from the pre-captured encoded value
+    const result = fs.decodeFeedUrls(encoded);
+    assert.strictEqual(result.error, null);
+    assert.strictEqual(result.urls.length, 2);
+  });
+});


### PR DESCRIPTION
Implements fully self-contained feed sharing:
- js/share.js: pure encode/decode/validate/planImport functions;
  feed URLs serialized as base64 JSON appended as ?import= param
- index.html: "Share feeds" button in feeds toolbar, share-feeds
  dialog (selection + link display), feed-import dialog (shown on
  load when ?import= detected)
- css/style.css: styles for both new dialogs and updated feeds
  toolbar to support side-by-side buttons
- js/app.js: wires share-feeds and import flows; ?import= param
  stripped immediately in init() so refresh never re-prompts;
  deduplication via FeedShare.planImport reuses existing addFeedByUrl
- tests/share.test.js: 32 tests covering encode/decode/validate,
  15-feed hard cap, deduplication (planImport), and URL param
  handling including history.replaceState via JSDOM

https://claude.ai/code/session_016ZeDhQqcm7sB2Qw81YS1LJ