### PR TITLE
Fix next/previous article navigation dumping back to feed list

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1269,7 +1269,6 @@
       const feed = feedMap[art.feedId];
       Storage.markArticleRead(art.id, true);
       UI.showArticle(art, feed, list, i);
-      renderAll();
     });
 
     document.getElementById('btn-next-article')?.addEventListener('click', () => {
@@ -1280,7 +1279,6 @@
       const feed = feedMap[art.feedId];
       Storage.markArticleRead(art.id, true);
       UI.showArticle(art, feed, list, i);
-      renderAll();
     });
   }
 


### PR DESCRIPTION
Removed erroneous renderAll() calls from the prev/next article button
handlers. renderAll() was resetting currentFeedId and pushing a new hash,
which triggered the hashchange listener and navigated away from the article
view. UI.showArticle() already handles everything needed for navigation.