### PR TITLE
Improve Substack discovery fallback for custom domains

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -502,13 +502,13 @@
         try {
           const discovered = await FeedParser.discoverFeedUrl(appleUrl, proxy);
           if (discovered && discovered !== feedUrl) {
+            parsed = await FeedParser.fetchAndParse(discovered, proxy);
+            feedUrl = discovered;
             const f = await Storage.getFeeds().then((list) => list.find((x) => x.id === feedId));
             if (f) {
               f.url = discovered;
               await Storage.updateFeed(f);
             }
-            parsed = await FeedParser.fetchAndParse(discovered, proxy);
-            feedUrl = discovered;
             break;
           }
         } catch {
@@ -521,13 +521,13 @@
         try {
           const discovered = await FeedParser.discoverFeedUrl(discoveryFallbackUrl, proxy);
           if (discovered && discovered !== feedUrl) {
+            parsed = await FeedParser.fetchAndParse(discovered, proxy);
+            feedUrl = discovered;
             const f = await Storage.getFeeds().then((list) => list.find((x) => x.id === feedId));
             if (f) {
               f.url = discovered;
               await Storage.updateFeed(f);
             }
-            parsed = await FeedParser.fetchAndParse(discovered, proxy);
-            feedUrl = discovered;
             break;
           }
         } catch {

--- a/js/app.js
+++ b/js/app.js
@@ -538,7 +538,7 @@
     if (!parsed) {
       const f = await Storage.getFeeds().then((list) => list.find((x) => x.id === feedId));
       if (f) {
-        showToast(`Removed "${f.title || f.url}" — feed not found. Try pasting the RSS URL in the RSS tab.`, 6000);
+        showToast(`Removed "${f.title || f.url}" — couldn't load feed from ${feedUrl}. Try pasting the RSS URL directly.`, 8000);
         await Storage.deleteFeed(feedId);
       }
       await loadFeeds();
@@ -897,24 +897,31 @@
           const h = u.hostname.toLowerCase();
           let feedUrl;
           let subName;
+          let discoveryFallbackUrl;
           if (h === 'substack.com' || h === 'www.substack.com') {
             const match = u.pathname.match(/^\/@([^/]+)/);
             if (match) {
               feedUrl = `https://${match[1]}.substack.com/feed`;
               subName = match[1];
+              // Use newsletter homepage as discovery fallback: it has the RSS link and
+              // if the newsletter uses a custom domain the fetched HTML will have the
+              // absolute custom-domain feed URL.
+              discoveryFallbackUrl = `https://${match[1]}.substack.com`;
             } else {
               const base = u.origin.replace(/\/$/, '');
               const path = u.pathname.replace(/\/p\/[^/]*$/, '').replace(/\/$/, '') || '';
               feedUrl = base + path + '/feed';
               subName = u.hostname;
+              discoveryFallbackUrl = base + (path || '');
             }
           } else {
             const base = u.origin.replace(/\/$/, '');
             const path = u.pathname.replace(/\/p\/[^/]*$/, '').replace(/\/$/, '') || '';
             feedUrl = base + path + '/feed';
             subName = u.hostname.replace(/^www\./, '').replace(/\.substack\.com$/, '') || u.hostname;
+            discoveryFallbackUrl = base + (path || '');
           }
-          const ok = await addFeedByUrl(feedUrl, subName, '', url);
+          const ok = await addFeedByUrl(feedUrl, subName, '', discoveryFallbackUrl);
           if (ok) closeAddFeedDialog();
         } catch {
           hintRss.textContent = 'Invalid URL.';


### PR DESCRIPTION
## Summary

PR #9 fixed the Substack `subName` bug and added an initial discovery fallback, but that fallback pointed at the original profile URL (`substack.com/@handle`), which doesn't reliably carry an RSS `<link>` tag. This PR was written and pushed right after #9 merged, but never made it into `main` since #9 was already closed by then.

- Point the Substack discovery fallback at the newsletter homepage (`https://handle.substack.com`) instead of the profile page — this page reliably has the RSS `<link>` tag, and since the CORS proxy follows redirects, if the newsletter uses a **custom domain**, the fetched HTML will contain the absolute custom-domain feed URL.
- Improve the final "couldn't add feed" toast message to name the feed and suggest pasting the RSS URL directly.

## Test plan

- [ ] Paste `https://substack.com/@benandstuff?...` (a newsletter using a custom domain) — should now resolve via the homepage fallback instead of silently removing the feed
- [ ] `npm test` passes (74 tests)

https://claude.ai/code/session_01NUH4auJP2d8WeYuSSh5ygS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUH4auJP2d8WeYuSSh5ygS)_