### PR TITLE
Fix podcast feeds showing only one episode after add

### DIFF
--- a/js/feed-parser.js
+++ b/js/feed-parser.js
@@ -55,11 +55,12 @@ function parseRSS2JSON(data) {
       const enclosureUrl = (enc?.url || enc?.link || '').trim();
       const guid = (item.guid || '').trim();
       const itemLink = item.link || item.url || guid || '';
+      const itemTitle = item.title || '(No title)';
       return {
-        title: item.title || '(No title)',
+        title: itemTitle,
         link: itemLink,
         guid: (guid && guid.startsWith('http')) ? guid : undefined,
-        uid: guid || itemLink || enclosureUrl || item.title || '',
+        uid: guid || itemLink || enclosureUrl || itemTitle,
         content: item.content || item.description || '',
         published: item.pubDate ? new Date(item.pubDate).getTime() : Date.now(),
         author: item.author || '',

--- a/js/feed-parser.js
+++ b/js/feed-parser.js
@@ -54,10 +54,12 @@ function parseRSS2JSON(data) {
       const enc = item.enclosure;
       const enclosureUrl = (enc?.url || enc?.link || '').trim();
       const guid = (item.guid || '').trim();
+      const itemLink = item.link || item.url || guid || '';
       return {
         title: item.title || '(No title)',
-        link: item.link || item.url || guid || '',
+        link: itemLink,
         guid: (guid && guid.startsWith('http')) ? guid : undefined,
+        uid: guid || itemLink || enclosureUrl || item.title || '',
         content: item.content || item.description || '',
         published: item.pubDate ? new Date(item.pubDate).getTime() : Date.now(),
         author: item.author || '',
@@ -124,6 +126,7 @@ function parseRSS(doc) {
       title: itemTitle,
       link: itemLink || guid,
       guid: (guid && guid.startsWith('http')) ? guid : undefined,
+      uid: guid || itemLink || enclosureUrl || itemTitle,
       content,
       published: Number.isNaN(published) ? Date.now() : published,
       author,
@@ -176,11 +179,13 @@ function parseAtom(doc) {
 
     const isPodcast = durationSeconds > 0 || (enclosureEl?.getAttribute('type') || '').startsWith('audio/');
     const idEl = entry.querySelector('id');
-    const guid = (idEl?.textContent?.trim() || '').startsWith('http') ? idEl.textContent.trim() : undefined;
+    const idRaw = idEl?.textContent?.trim() || '';
+    const guid = idRaw.startsWith('http') ? idRaw : undefined;
     items.push({
       title: itemTitle,
       link: itemLink,
       guid,
+      uid: idRaw || itemLink || enclosureUrl || itemTitle,
       content,
       published: Number.isNaN(published) ? Date.now() : published,
       author,

--- a/js/storage.js
+++ b/js/storage.js
@@ -158,8 +158,8 @@ async function getArticle(articleId) {
   });
 }
 
-function articleId(feedId, link) {
-  return btoa(encodeURIComponent(feedId + '|' + (link || ''))).replace(/[/+=]/g, '_').slice(0, 120);
+function articleId(feedId, key) {
+  return btoa(encodeURIComponent(feedId + '|' + (key || ''))).replace(/[/+=]/g, '_').slice(0, 120);
 }
 
 async function upsertArticles(feedId, items) {
@@ -168,7 +168,7 @@ async function upsertArticles(feedId, items) {
   const existingIds = new Set(existing.map((a) => a.id));
   const toPut = [];
   for (const item of items) {
-    const id = articleId(feedId, item.link);
+    const id = articleId(feedId, item.uid || item.link);
     const rec = {
       id,
       feedId,

--- a/js/storage.js
+++ b/js/storage.js
@@ -166,9 +166,14 @@ async function upsertArticles(feedId, items) {
   const database = await openDB();
   const existing = await getArticles({ feedId });
   const existingIds = new Set(existing.map((a) => a.id));
+  const linkCounts = {};
+  for (const item of items) {
+    if (item.link) linkCounts[item.link] = (linkCounts[item.link] || 0) + 1;
+  }
   const toPut = [];
   for (const item of items) {
-    const id = articleId(feedId, item.uid || item.link);
+    const linkIsUnique = item.link && linkCounts[item.link] === 1;
+    const id = articleId(feedId, linkIsUnique ? item.link : (item.uid || item.link));
     const rec = {
       id,
       feedId,

--- a/tests/feed-parser.test.js
+++ b/tests/feed-parser.test.js
@@ -93,6 +93,33 @@ describe('FeedParser parseXML (RSS)', () => {
     assert.ok(typeof feed.items[0].published === 'number');
     assert.ok(feed.items[0].published > 0);
   });
+
+  it('derives a distinct uid per item from guid even when link is shared', () => {
+    const rss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+  <title>Podcast</title>
+  <link>https://show.example.com</link>
+  <item>
+    <title>Episode 1</title>
+    <link>https://show.example.com</link>
+    <guid>episode-1</guid>
+    <pubDate>Mon, 01 Jan 2024 12:00:00 GMT</pubDate>
+  </item>
+  <item>
+    <title>Episode 2</title>
+    <link>https://show.example.com</link>
+    <guid>episode-2</guid>
+    <pubDate>Tue, 02 Jan 2024 12:00:00 GMT</pubDate>
+  </item>
+</channel>
+</rss>`;
+    const feed = FeedParser.parseXML(rss);
+    assert.strictEqual(feed.items.length, 2);
+    assert.notStrictEqual(feed.items[0].uid, feed.items[1].uid);
+    assert.strictEqual(feed.items[0].uid, 'episode-1');
+    assert.strictEqual(feed.items[1].uid, 'episode-2');
+  });
 });
 
 describe('FeedParser parseXML (Atom)', () => {


### PR DESCRIPTION
Many podcast feeds reuse the same <link> (show homepage) on every
<item> and rely on <guid> for per-episode uniqueness. Article
dedup keyed off item.link alone, so all episodes collapsed onto a
single IndexedDB record, leaving only the last-processed (oldest)
item. Derive a uid that prefers guid, falling back to link/
enclosureUrl/title, and use it as the dedup key.